### PR TITLE
run checks (flake8 with name checks) in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+      - image: circleci/python:3.6.10
 
     working_directory: ~/repo
 
@@ -23,7 +16,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt"}}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -32,12 +25,18 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            make install-packages
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt"}}
+
+      - run:
+          name: run checks
+          command: |
+            . venv/bin/activate
+            make check
 
       # run tests!
       # this example uses Django's built-in test-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ python:
   - pypy3
 
 install:
-  - pip install -r requirements.txt
-  - pip install flake8
+  - make install-packages
   - pip install python-coveralls
 
 script:
-  - flake8 .
+  - make check
   - nosetests
   - coverage run --source=. -m unittest discover
 

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,19 @@
 .PHONY: all
 all: check test build
 
+.PHONY: install-packages
+install-packages:
+	pip3 install --upgrade \
+	  -r dev-requirements.txt \
+	  -r requirements.txt
+
 .PHONY: clean
 clean:
 	rm -rf dist build */*.egg-info *.egg-info
 
 .PHONY: check
 check:
-	python3 setup.py flake8
+	flake8
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make check
 ```
 or
 ```bash
-python3 setup.py flake8
+flake8
 ```
 
 ### Run unit tests

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pep8-naming

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git,__pycache__,./venv
+max-line-length = 120

--- a/wordgame/test/test_take.py
+++ b/wordgame/test/test_take.py
@@ -4,7 +4,7 @@ from wordgame.__main__ import take
 
 
 class TestTake(unittest.TestCase):
-    def test_number_of_None(self):
+    def test_number_of_none(self):
         expected = [0, 1, 2]
         actual = list(take(None, range(3)))
         self.assertEqual(actual, expected)


### PR DESCRIPTION
Also resolving the following warning by not calling flake8 via setup.py:
WARNING: flake8 setuptools integration is deprecated and scheduled for removal in 4.x.  For more information, see https://gitlab.com/pycqa/flake8/issues/544